### PR TITLE
Fixing vblank and hblank registers as well as seperate hdmi vblank and hblank signal to allow for cropping

### DIFF
--- a/Odyssey2.sv
+++ b/Odyssey2.sv
@@ -522,8 +522,8 @@ vp_console vp
 	.l_o            (luma),
 	.hsync_n_o      (HSync),
 	.vsync_n_o      (VSync),
-	.hblank_o       (HBlank),
-	.vbl_o          (VBlank),
+	.hblank_o          (HBlank),
+	.vblank_o          (VBlank),
 
 	// Sound
 	.snd_o          (),

--- a/Odyssey2.sv
+++ b/Odyssey2.sv
@@ -522,7 +522,7 @@ vp_console vp
 	.l_o            (luma),
 	.hsync_n_o      (HSync),
 	.vsync_n_o      (VSync),
-	.hbl_o          (HBlank),
+	.hblank_o       (HBlank),
 	.vbl_o          (VBlank),
 
 	// Sound

--- a/rtl/i8244/i8244_comp_pack-p.vhd
+++ b/rtl/i8244/i8244_comp_pack-p.vhd
@@ -41,6 +41,7 @@ package i8244_comp_pack is
       ms_i          : in  std_logic;
       vbl_i         : in  std_logic;
       hbl_o         : out std_logic;
+		  hblank_o      : out std_logic;
       hsync_o       : out std_logic;
       vsync_o       : out std_logic;
       bg_o          : out std_logic;

--- a/rtl/i8244/i8244_comp_pack-p.vhd
+++ b/rtl/i8244/i8244_comp_pack-p.vhd
@@ -41,7 +41,8 @@ package i8244_comp_pack is
       ms_i          : in  std_logic;
       vbl_i         : in  std_logic;
       hbl_o         : out std_logic;
-		  hblank_o      : out std_logic;
+      hblank_o      : out std_logic;
+      vblank_o      : out std_logic;
       hsync_o       : out std_logic;
       vsync_o       : out std_logic;
       bg_o          : out std_logic;

--- a/rtl/i8244/i8244_core.vhd
+++ b/rtl/i8244/i8244_core.vhd
@@ -67,7 +67,8 @@ entity i8244_core is
     vsync_o    : out std_logic;
     ms_i       : in  std_logic;
     hbl_o      : out std_logic;
-	  hblank_o   : out std_logic;
+    hblank_o   : out std_logic;
+    vblank_o   : out std_logic;
     vbl_i      : in  std_logic;
     vbl_o      : out std_logic;
     cx_i       : in  std_logic;
@@ -193,7 +194,8 @@ begin
       hpos_o        => hpos_s,
       vpos_o        => vpos_s,
       hor_int_o     => hor_int_s,
-		hblank_o      => hblank_o
+      hblank_o      => hblank_o,
+      vblank_o      => vblank_o
     );
   --
   vbl_o <= vbl_s;

--- a/rtl/i8244/i8244_core.vhd
+++ b/rtl/i8244/i8244_core.vhd
@@ -67,6 +67,7 @@ entity i8244_core is
     vsync_o    : out std_logic;
     ms_i       : in  std_logic;
     hbl_o      : out std_logic;
+	  hblank_o   : out std_logic;
     vbl_i      : in  std_logic;
     vbl_o      : out std_logic;
     cx_i       : in  std_logic;
@@ -191,7 +192,8 @@ begin
       vbl_o         => vbl_s,
       hpos_o        => hpos_s,
       vpos_o        => vpos_s,
-      hor_int_o     => hor_int_s
+      hor_int_o     => hor_int_s,
+		hblank_o      => hblank_o
     );
   --
   vbl_o <= vbl_s;

--- a/rtl/i8244/i8244_core_comp_pack-p.vhd
+++ b/rtl/i8244/i8244_core_comp_pack-p.vhd
@@ -43,7 +43,8 @@ package i8244_core_comp_pack is
       vsync_o    : out std_logic;
       ms_i       : in  std_logic;
       hbl_o      : out std_logic;
-      hblank_o   : out std_logic;
+		hblank_o   : out std_logic;
+		vblank_o   : out std_logic;
       vbl_i      : in  std_logic;
       vbl_o      : out std_logic;
       cx_i       : in  std_logic;
@@ -81,6 +82,7 @@ package i8244_core_comp_pack is
       hblank_o   : out std_logic;
       vbl_i      : in  std_logic;
       vbl_o      : out std_logic;
+      vblank_o   : out std_logic;
       cx_i       : in  std_logic;
       l_o        : out std_logic;
       cs_n_i     : in  std_logic;

--- a/rtl/i8244/i8244_core_comp_pack-p.vhd
+++ b/rtl/i8244/i8244_core_comp_pack-p.vhd
@@ -43,6 +43,7 @@ package i8244_core_comp_pack is
       vsync_o    : out std_logic;
       ms_i       : in  std_logic;
       hbl_o      : out std_logic;
+      hblank_o   : out std_logic;
       vbl_i      : in  std_logic;
       vbl_o      : out std_logic;
       cx_i       : in  std_logic;
@@ -77,6 +78,7 @@ package i8244_core_comp_pack is
       vsync_o    : out std_logic;
       ms_i       : in  std_logic;
       hbl_o      : out std_logic;
+      hblank_o   : out std_logic;
       vbl_i      : in  std_logic;
       vbl_o      : out std_logic;
       cx_i       : in  std_logic;

--- a/rtl/i8244/i8244_sync_gen.vhd
+++ b/rtl/i8244/i8244_sync_gen.vhd
@@ -67,7 +67,8 @@ entity i8244_sync_gen is
     vbl_o         : out std_logic;
     hpos_o        : out pos_t;
     vpos_o        : out pos_t;
-    hor_int_o     : out std_logic
+    hor_int_o     : out std_logic;
+	  hblank_o      : out std_logic
   );
 
 end i8244_sync_gen;
@@ -127,6 +128,8 @@ architecture rtl of i8244_sync_gen is
   signal bg_q          : std_logic;
   signal vbl_q         : std_logic;
   signal hor_int_q     : std_logic;
+  
+  signal hblank_q    : std_logic;
 
 begin
 
@@ -158,6 +161,7 @@ begin
       bg_q         <= '0';
       vbl_q        <= '0';
       hor_int_q    <= '0';
+		hblank_q     <= '0';
 
     elsif rising_edge(clk_i) then
       last_frame_line_v := last_frame_line_c(is_pal_g);
@@ -176,7 +180,7 @@ begin
         -- horizontal position counter ----------------------------------------
         vinc_v   := false;
         if    vbl_sync_v then
-          -- sync to pixel 1 in new line
+          -- sync to pixel 1
           hpos_q <= to_pos_f(1);
         else
           if hpos_q = last_hpos_c then
@@ -220,6 +224,7 @@ begin
 
           if hpos_q = last_hsync_c and vpos_q = 0 then
             hbl_q   <= '0';
+				hblank_q <= '0';
           end if;
 
           -- hsync
@@ -228,6 +233,13 @@ begin
           elsif hpos_q = last_hsync_c then
             hsync_q <= '0';
           end if;
+			 
+			 --real hblank
+			 if hpos_q = first_hblank_c - 1  then
+				hblank_q <= '1';
+			 elsif hpos_q = last_hpos_c -1 then
+				hblank_q <= '0';
+			 end if;
 
           -- vsync
           if    vpos_q = first_vsync_c - 1 then
@@ -281,5 +293,6 @@ begin
   hpos_o        <= hpos_q;
   vpos_o        <= vpos_q;
   hor_int_o     <= hor_int_q;
+  hblank_o      <= hblank_q;
 
 end rtl;

--- a/rtl/i8244/i8244_sync_gen.vhd
+++ b/rtl/i8244/i8244_sync_gen.vhd
@@ -188,8 +188,8 @@ begin
         -- horizontal position counter ----------------------------------------
         vinc_v   := false;
         if    vbl_sync_v then
-          -- sync to pixel 1? in new line - lets try 0 to fix that artifact
-          hpos_q <= to_pos_f(0);
+          -- sync to pixel 1
+          hpos_q <= to_pos_f(1);
         else
           if hpos_q = last_hpos_c then
             hpos_q <= to_pos_f(0);

--- a/rtl/i8244/i8244_sync_gen.vhd
+++ b/rtl/i8244/i8244_sync_gen.vhd
@@ -68,7 +68,8 @@ entity i8244_sync_gen is
     hpos_o        : out pos_t;
     vpos_o        : out pos_t;
     hor_int_o     : out std_logic;
-	  hblank_o      : out std_logic
+    hblank_o      : out std_logic;
+    vblank_o	  : out std_logic
   );
 
 end i8244_sync_gen;
@@ -92,6 +93,11 @@ architecture rtl of i8244_sync_gen is
   constant last_hsync_c      : pos_t := first_hsync_c + to_pos_f(34-1);
   constant first_bg_c        : pos_t := first_hblank_c + to_pos_f(48);
   constant last_bg_c         : pos_t := first_bg_c + to_pos_f(18-1);
+  
+  constant hblank_start_c    : pos_t := to_pos_f(320);
+  
+  constant vblank_end_c      : pos_t := to_pos_f(1);
+
 
   -- constant last_hpos_c       : pos_t := to_pos_f(455);
   -- constant last_hblank_c     : pos_t := to_pos_f(455); -- 455 -- 87 total
@@ -112,8 +118,8 @@ architecture rtl of i8244_sync_gen is
     is_pal_c  => to_pos_f(312));
   constant first_vblank_c    : pos_t := last_vis_line_c + to_pos_f(0);
   constant last_vblank_c     : limits_t := (
-    is_ntsc_c => to_pos_f(1),
-    is_pal_c  => to_pos_f(0));
+    is_ntsc_c => to_pos_f(0),
+    is_pal_c  => to_pos_f(312));
   constant first_vsync_c     : pos_t := first_vblank_c + to_pos_f(16);
   constant last_vsync_c      : pos_t := first_vsync_c + to_pos_f(5);
 
@@ -129,7 +135,8 @@ architecture rtl of i8244_sync_gen is
   signal vbl_q         : std_logic;
   signal hor_int_q     : std_logic;
   
-  signal hblank_q    : std_logic;
+  signal hblank_q      : std_logic;
+  signal vblank_q      : std_logic;
 
 begin
 
@@ -162,6 +169,7 @@ begin
       vbl_q        <= '0';
       hor_int_q    <= '0';
 		hblank_q     <= '0';
+		vblank_q     <= '0';
 
     elsif rising_edge(clk_i) then
       last_frame_line_v := last_frame_line_c(is_pal_g);
@@ -180,8 +188,8 @@ begin
         -- horizontal position counter ----------------------------------------
         vinc_v   := false;
         if    vbl_sync_v then
-          -- sync to pixel 1
-          hpos_q <= to_pos_f(1);
+          -- sync to pixel 1? in new line - lets try 0 to fix that artifact
+          hpos_q <= to_pos_f(0);
         else
           if hpos_q = last_hpos_c then
             hpos_q <= to_pos_f(0);
@@ -210,6 +218,7 @@ begin
           vsync_q   <= '0';
           bg_q      <= '0';
           vbl_q     <= '1';
+			 vblank_q  <= '1';
         else
           -- hbl
           if    hpos_q = first_hblank_c - 1 then
@@ -259,10 +268,16 @@ begin
           if vinc_v then
             if    vpos_q = first_vblank_c then
               vbl_q <= '1';
+				  vblank_q <= '1';
             elsif vpos_q = last_vblank_v then
               vbl_q <= '0';
-            end if;
+				end if;
           end if;
+			 
+			 if vpos_q = vblank_end_c then
+			   vblank_q <= '0';
+			 end if;
+			 
 
           -- horizontal interrupt
           if    hpos_q = first_hor_int_c - 1 then
@@ -294,5 +309,6 @@ begin
   vpos_o        <= vpos_q;
   hor_int_o     <= hor_int_q;
   hblank_o      <= hblank_q;
+  vblank_o      <= vblank_q;
 
 end rtl;

--- a/rtl/i8244/i8244_top_sync.vhd
+++ b/rtl/i8244/i8244_top_sync.vhd
@@ -64,6 +64,7 @@ entity i8244_top_sync is
     ms_i       : in  std_logic;
     hbl_o      : out std_logic;
     hblank_o   : out std_logic;
+    vblank_o   : out std_logic;
     vbl_i      : in  std_logic;
     vbl_o      : out std_logic;
     cx_i       : in  std_logic;
@@ -119,7 +120,8 @@ begin
       vsync_o    => vsync_o,
       ms_i       => ms_i,
       hbl_o      => hbl_o,
-		hblank_o   => hblank_o,
+      hblank_o   => hblank_o,
+      vblank_o   => vblank_o,
       vbl_i      => vbl_i,
       vbl_o      => vbl_o,
       cx_i       => cx_i,

--- a/rtl/i8244/i8244_top_sync.vhd
+++ b/rtl/i8244/i8244_top_sync.vhd
@@ -63,6 +63,7 @@ entity i8244_top_sync is
     vsync_o    : out std_logic;
     ms_i       : in  std_logic;
     hbl_o      : out std_logic;
+	 hblank_o   : out std_logic;
     vbl_i      : in  std_logic;
     vbl_o      : out std_logic;
     cx_i       : in  std_logic;
@@ -118,6 +119,7 @@ begin
       vsync_o    => vsync_o,
       ms_i       => ms_i,
       hbl_o      => hbl_o,
+		hblank_o   => hblank_o,
       vbl_i      => vbl_i,
       vbl_o      => vbl_o,
       cx_i       => cx_i,

--- a/rtl/i8244/i8244_top_sync.vhd
+++ b/rtl/i8244/i8244_top_sync.vhd
@@ -63,7 +63,7 @@ entity i8244_top_sync is
     vsync_o    : out std_logic;
     ms_i       : in  std_logic;
     hbl_o      : out std_logic;
-	 hblank_o   : out std_logic;
+    hblank_o   : out std_logic;
     vbl_i      : in  std_logic;
     vbl_o      : out std_logic;
     cx_i       : in  std_logic;

--- a/rtl/vp_console.vhd
+++ b/rtl/vp_console.vhd
@@ -105,7 +105,8 @@ entity vp_console is
     vsync_n_o      : out std_logic;
     hbl_o          : out std_logic;
     vbl_o          : out std_logic;
-	 hblank_o       : out std_logic;
+    hblank_o       : out std_logic;
+    vblank_o       : out std_logic;
     -- Sound Interface --------------------------------------------------------
     snd_o          : out std_logic;
     snd_vec_o      : out std_logic_vector(3 downto 0);
@@ -353,6 +354,7 @@ begin
 		hblank_o   => hblank_o,
       vbl_i      => gnd_s,
       vbl_o      => vbl_s,
+      vblank_o   => vblank_o,
       cx_i       => gnd_s,
       l_o        => l_from_vdc_s,
       cs_n_i     => vdc_cs_n_s,

--- a/rtl/vp_console.vhd
+++ b/rtl/vp_console.vhd
@@ -105,6 +105,7 @@ entity vp_console is
     vsync_n_o      : out std_logic;
     hbl_o          : out std_logic;
     vbl_o          : out std_logic;
+	 hblank_o       : out std_logic;
     -- Sound Interface --------------------------------------------------------
     snd_o          : out std_logic;
     snd_vec_o      : out std_logic_vector(3 downto 0);
@@ -349,6 +350,7 @@ begin
       vsync_o    => vsync_s,
       ms_i       => vdd_s,
       hbl_o      => hbl_s,
+		hblank_o   => hblank_o,
       vbl_i      => gnd_s,
       vbl_o      => vbl_s,
       cx_i       => gnd_s,

--- a/rtl/vp_console_comp_pack-p.vhd
+++ b/rtl/vp_console_comp_pack-p.vhd
@@ -60,6 +60,7 @@ package vp_console_comp_pack is
       vsync_n_o      : out std_logic;
       hbl_o          : out std_logic;
       hblank_o       : out std_logic;
+      vblank_o       : out std_logic;
       vbl_o          : out std_logic;
       -- Sound Interface ------------------------------------------------------
       snd_o          : out std_logic;

--- a/rtl/vp_console_comp_pack-p.vhd
+++ b/rtl/vp_console_comp_pack-p.vhd
@@ -59,6 +59,7 @@ package vp_console_comp_pack is
       hsync_n_o      : out std_logic;
       vsync_n_o      : out std_logic;
       hbl_o          : out std_logic;
+      hblank_o       : out std_logic;
       vbl_o          : out std_logic;
       -- Sound Interface ------------------------------------------------------
       snd_o          : out std_logic;


### PR DESCRIPTION
The hblank_o signals allow for the overscan to be cut off in atlantis.
Vblank_o was used so that the vbl_q signal could be adjusted to so that the "ground" in atlantis appears high and makes contact with the sprites

The hblank_interrupt was removed, looking online there is no evidence that it causes a routine, also simulations show slowdowns caused by calling the vblank routine during a hblank. Removing that fixed slowdowns in blockout. Removing the "not" moves the colour changes closer to the hblank

The vblank interrupt is now triggered by the vblank signal and is only lowered by reading the status register, this fixes slowdowns in great wall street where on some frames it gets stuck waiting for an interrupt due to the vblank register being low

There are still minor visual glitches, only in blockout and killer bees as well as great wall street where horizontal interrupt, hblank and possibly the total line length need to be adjusted so that the colour changes are off screen. The hblank_o signal can be cropped on the overside for killer bees and other artifacts in blockout and great wall street. 